### PR TITLE
use latest supertest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "supertest-koa-agent",
   "description": "Converts a Koa app into a supertest compatible agent instance.",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "author": "Wil Moore III <wil.moore@wilmoore.com>",
   "bugs": {
     "url": "https://github.com/wilmoore/node-supertest-koa-agent/issues"
   },
   "dependencies": {
-    "supertest": "^1.0.1"
+    "supertest": "^2.0.0"
   },
   "devDependencies": {
     "istanbul": "^0.3.14",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "supertest-koa-agent",
   "description": "Converts a Koa app into a supertest compatible agent instance.",
-  "version": "0.3.0",
+  "version": "0.2.1",
   "author": "Wil Moore III <wil.moore@wilmoore.com>",
   "bugs": {
     "url": "https://github.com/wilmoore/node-supertest-koa-agent/issues"


### PR DESCRIPTION
Added current version of supertest (which uses newer version of superagent that fixes [issue 722](https://github.com/visionmedia/superagent/issues/722)) in order to return promises in mocha tests.
